### PR TITLE
Fix /bin/bash not found error for NixOS

### DIFF
--- a/runTcpQuality.sh
+++ b/runTcpQuality.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # TcpQuality 节点 TCP 丢包探测脚本
 # 用法: bash <(curl -sL https://raw.githubusercontent.com/ibsgss/TcpQuality/main/runTcpQuality.sh)


### PR DESCRIPTION
#2 