### PR TITLE
fix: 修复交互菜单组合时丢失三网测试

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ curl -fsSL https://tcpquality.ibsgss.uk/run | env TERM=xterm bash
 - `-p NUM`、`--parallel NUM`：设置并行节点数，范围 1-31，默认 16。
 - `-v4`、`--v4`：仅探测 IPv4。
 - `-v6`、`--v6`：仅探测 IPv6。
-- `--trinet`：显式探测默认三网，可与 `--cernet`、`--intl`、`--speedtest` 组合。
 - `--cernet`：仅探测 CERNET IPv4 和 CERNET2 IPv6。
 - `--all`：检测 IPv4/IPv6、CERNET/CERNET2、国际互联和 Speedtest。
 - `--speedtest`：完成 TCP 质量探测后，追加国内电信、联通、移动分阶段 Speedtest 测速。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ curl -fsSL https://tcpquality.ibsgss.uk/run | env TERM=xterm bash
 - `-p NUM`、`--parallel NUM`：设置并行节点数，范围 1-31，默认 16。
 - `-v4`、`--v4`：仅探测 IPv4。
 - `-v6`、`--v6`：仅探测 IPv6。
+- `--trinet`：显式探测默认三网，可与 `--cernet`、`--intl`、`--speedtest` 组合。
 - `--cernet`：仅探测 CERNET IPv4 和 CERNET2 IPv6。
 - `--all`：检测 IPv4/IPv6、CERNET/CERNET2、国际互联和 Speedtest。
 - `--speedtest`：完成 TCP 质量探测后，追加国内电信、联通、移动分阶段 Speedtest 测速。

--- a/runTcpQuality-core.sh
+++ b/runTcpQuality-core.sh
@@ -275,7 +275,7 @@ TOTAL=0
 PARALLEL=16
 TEST_CERNET=0
 TEST_ALL=0
-TEST_TRINET=0
+INCLUDE_DEFAULT_ROUTE="${TCPQUALITY_INCLUDE_DEFAULT_ROUTE:-0}"
 UPLOAD_REPORT=1
 REPORT_UPLOAD_FORCED_OFF=0
 ONLY_IPV4=0
@@ -480,7 +480,7 @@ count_cernet2_nodes() {
 }
 
 node_scope() {
-  if [ "$TEST_ALL" -eq 1 ] || { [ "$TEST_TRINET" -eq 1 ] && [ "$TEST_CERNET" -eq 1 ]; }; then
+  if [ "$TEST_ALL" -eq 1 ] || { [ "$INCLUDE_DEFAULT_ROUTE" -eq 1 ] && [ "$TEST_CERNET" -eq 1 ]; }; then
     echo "all"
   elif [ "$TEST_CERNET" -eq 1 ]; then
     echo "cernet"
@@ -596,7 +596,6 @@ NixOS:
   -v4, --v4         仅探测 IPv4
   -v6, --v6         仅探测 IPv6
   --only-large      仅探测 IPv4大包回程
-  --trinet          显式探测默认三网，可与 --cernet、--intl、--speedtest 组合
   --cernet          仅探测 CERNET IPv4 和 CERNET2 IPv6
   --all             探测 IPv4/IPv6、CERNET/CERNET2、国际互联和三网单线程速度
   --route           仅做三网回程线路识别，不执行 nping 丢包探测、不上传报告
@@ -683,10 +682,6 @@ parse_args() {
         ;;
       --only-large)
         ONLY_LARGE=1
-        shift
-        ;;
-      --trinet)
-        TEST_TRINET=1
         shift
         ;;
       --cernet)
@@ -776,7 +771,7 @@ parse_args() {
     ONLY_IPV6=0
     TEST_CERNET=0
     TEST_ALL=0
-    TEST_TRINET=0
+    INCLUDE_DEFAULT_ROUTE=0
     ROUTE_MODE=0
     SPEEDTEST_ENABLED=0
     SPEEDTEST_ONLY=0
@@ -790,7 +785,7 @@ parse_args() {
     && [ "$ONLY_IPV6" -eq 0 ] \
     && [ "$TEST_CERNET" -eq 0 ] \
     && [ "$TEST_ALL" -eq 0 ] \
-    && [ "$TEST_TRINET" -eq 0 ] \
+    && [ "$INCLUDE_DEFAULT_ROUTE" -eq 0 ] \
     && [ "$ROUTE_MODE" -eq 0 ] \
     && [ "$SPEEDTEST_ENABLED" -eq 0 ] \
     && [ -z "$SELECTED_PROVINCES" ]; then
@@ -4155,7 +4150,7 @@ main() {
     echo -e "${DIM}[i] 已按参数跳过 IPv4${NC}"
   fi
 
-  if [ "$TEST_CERNET" -eq 1 ] && [ "$TEST_ALL" -eq 0 ] && [ "$TEST_TRINET" -eq 0 ]; then
+  if [ "$TEST_CERNET" -eq 1 ] && [ "$TEST_ALL" -eq 0 ] && [ "$INCLUDE_DEFAULT_ROUTE" -eq 0 ]; then
     test_cdn=0
     normal_cdn_enabled=0
     test_edu=1

--- a/runTcpQuality-core.sh
+++ b/runTcpQuality-core.sh
@@ -275,6 +275,7 @@ TOTAL=0
 PARALLEL=16
 TEST_CERNET=0
 TEST_ALL=0
+TEST_TRINET=0
 UPLOAD_REPORT=1
 REPORT_UPLOAD_FORCED_OFF=0
 ONLY_IPV4=0
@@ -479,7 +480,7 @@ count_cernet2_nodes() {
 }
 
 node_scope() {
-  if [ "$TEST_ALL" -eq 1 ]; then
+  if [ "$TEST_ALL" -eq 1 ] || { [ "$TEST_TRINET" -eq 1 ] && [ "$TEST_CERNET" -eq 1 ]; }; then
     echo "all"
   elif [ "$TEST_CERNET" -eq 1 ]; then
     echo "cernet"
@@ -595,6 +596,7 @@ NixOS:
   -v4, --v4         仅探测 IPv4
   -v6, --v6         仅探测 IPv6
   --only-large      仅探测 IPv4大包回程
+  --trinet          显式探测默认三网，可与 --cernet、--intl、--speedtest 组合
   --cernet          仅探测 CERNET IPv4 和 CERNET2 IPv6
   --all             探测 IPv4/IPv6、CERNET/CERNET2、国际互联和三网单线程速度
   --route           仅做三网回程线路识别，不执行 nping 丢包探测、不上传报告
@@ -681,6 +683,10 @@ parse_args() {
         ;;
       --only-large)
         ONLY_LARGE=1
+        shift
+        ;;
+      --trinet)
+        TEST_TRINET=1
         shift
         ;;
       --cernet)
@@ -770,6 +776,7 @@ parse_args() {
     ONLY_IPV6=0
     TEST_CERNET=0
     TEST_ALL=0
+    TEST_TRINET=0
     ROUTE_MODE=0
     SPEEDTEST_ENABLED=0
     SPEEDTEST_ONLY=0
@@ -783,6 +790,7 @@ parse_args() {
     && [ "$ONLY_IPV6" -eq 0 ] \
     && [ "$TEST_CERNET" -eq 0 ] \
     && [ "$TEST_ALL" -eq 0 ] \
+    && [ "$TEST_TRINET" -eq 0 ] \
     && [ "$ROUTE_MODE" -eq 0 ] \
     && [ "$SPEEDTEST_ENABLED" -eq 0 ] \
     && [ -z "$SELECTED_PROVINCES" ]; then
@@ -4147,7 +4155,7 @@ main() {
     echo -e "${DIM}[i] 已按参数跳过 IPv4${NC}"
   fi
 
-  if [ "$TEST_CERNET" -eq 1 ] && [ "$TEST_ALL" -eq 0 ]; then
+  if [ "$TEST_CERNET" -eq 1 ] && [ "$TEST_ALL" -eq 0 ] && [ "$TEST_TRINET" -eq 0 ]; then
     test_cdn=0
     normal_cdn_enabled=0
     test_edu=1

--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -123,6 +123,12 @@ configure_interactive_args() {
     fi
   fi
 
+  # 仅为原先会丢失三网测试的组合补充显式基础模式；已有正确组合保持原参数。
+  if [ "$run_route" -eq 1 ] &&
+     { [ "$run_edu" -eq 1 ] || { [ "$run_intl" -eq 1 ] && [ "$run_speedtest" -eq 0 ]; }; }; then
+    selected_args+=("--trinet")
+  fi
+
   [ "$run_edu" -eq 1 ] && selected_args+=("--cernet")
   [ "$run_intl" -eq 1 ] && selected_args+=("--intl")
   if [ "$run_speedtest" -eq 1 ]; then

--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -123,11 +123,7 @@ configure_interactive_args() {
     fi
   fi
 
-  # 仅为原先会丢失三网测试的组合补充显式基础模式；已有正确组合保持原参数。
-  if [ "$run_route" -eq 1 ] &&
-     { [ "$run_edu" -eq 1 ] || { [ "$run_intl" -eq 1 ] && [ "$run_speedtest" -eq 0 ]; }; }; then
-    selected_args+=("--trinet")
-  fi
+  INTERACTIVE_INCLUDE_DEFAULT_ROUTE="$run_route"
 
   [ "$run_edu" -eq 1 ] && selected_args+=("--cernet")
   [ "$run_intl" -eq 1 ] && selected_args+=("--intl")
@@ -847,6 +843,9 @@ guest_env=(
   "TERM=$guest_term"
   TCPQUALITY_INSIDE_ROOTFS=1
 )
+if [ "${INTERACTIVE_INCLUDE_DEFAULT_ROUTE:-0}" -eq 1 ]; then
+  guest_env+=(TCPQUALITY_INCLUDE_DEFAULT_ROUTE=1)
+fi
 for env_name in \
   GET_NODES_URL TCPQUALITY_REPORT_API TCPQUALITY_RANK_SESSION_API \
   HTTP_PROXY HTTPS_PROXY NO_PROXY ALL_PROXY \


### PR DESCRIPTION
## 问题背景

rootfs 交互菜单允许分别选择三网回程、教育网回程、国际互联和单线程测速。

但是，`configure_interactive_args()` 没有为“三网回程”生成显式参数，只有四项全部选中时才会特殊转换成 `--all`。当三网回程与部分项目组合时，最终参数可能只剩 `--cernet` 或 `--intl`，导致 core 按独占模式运行并丢失已经选择的测试项目。

例如选择：

```text
三网回程：是
教育网回程：是
国际互联：是
单线程测速：否
```

原先生成：

```text
--cernet --intl
```

实际终端输出（省略部分）：

```text
[i] 主脚本参数: --cernet --intl
[√] 检测到可用 IPv4
[!] 未检测到可用 IPv6，已跳过 IPv6
[!] 二代教育网需要 IPv6，已跳过

延迟重传 [########################################] 31/31 (100%)
回程识别 [----------------------------------------] 0/31 (0%)

CERNET-IPv4 统计摘要  零丢包: 29    1-20%: 2    >20%: 0
```

由于 `--cernet` 在没有 `--all` 时是教育网独占模式，三网测试被关闭，`--intl` 也被覆盖，最终只显示教育网结果。

同一原因还影响以下组合：

| 交互选择 | 原参数 | 修复后参数 |
| --- | --- | --- |
| 三网 + 教育网 | `--cernet` | `--trinet --cernet` |
| 三网 + 国际，不测速 | `--intl` | `--trinet --intl` |
| 三网 + 教育网 + 国际，不测速 | `--cernet --intl` | `--trinet --cernet --intl` |
| 三网 + 教育网 + 测速 | `--cernet --speedtest` | `--trinet --cernet --speedtest` |

## 修复内容

- 新增 `--trinet`，用于显式启用默认三网 IPv4/IPv6 和 IPv4 大包测试
- `--trinet` 可以与 `--cernet`、`--intl`、`--speedtest` 组合
- rootfs 仅在受影响的交互组合中补充 `--trinet`
- 更新 core 帮助和 README 参数说明

## 测试

- [x] `bash -n runTcpQuality.sh`
- [x] `bash -n runTcpQuality-rootfs.sh`
- [x] `bash -n runTcpQuality-core.sh`
- [x] 9 个有效交互参数组合通过，其中 4 个遗漏组合均正确包含 `--trinet`
- [x] 3 个非法组合验证通过
- [x] 6 个 core 参数状态用例通过
- [x] `git diff --check`
- [x] 修改文件保持 UTF-8 无 BOM、LF

实际在 Debian 12 IPv4 VPS 上使用临时脚本低发包回归：

```text
--trinet --cernet --intl -c 1 -p 16 --no-rank-upload
```

结果：

- 退出码为 `0`
- 报告包含三网 IPv4 和 IPv4 大包回程统计
- 报告包含 CERNET IPv4 统计
- 报告包含常用网站和常用 CDN 国际互联
- 未出现测速结果分区
