### PR TITLE
Fix rootfs manifest awk warning

### DIFF
--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -515,7 +515,7 @@ rootfs_source_base() {
 parse_rootfs_manifest() {
   local manifest="$1" arch="$2"
   awk -v wanted="$arch" '
-    $0 ~ "\\\"" wanted "\\\"[[:space:]]*:" { inside=1; next }
+    $0 ~ ("\"" wanted "\"[[:space:]]*:") { inside=1; next }
     inside && /"file"[[:space:]]*:/ {
       line=$0; sub(/^.*"file"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); file=line
     }


### PR DESCRIPTION
## Summary
- avoid an unnecessary escaped quote in the awk dynamic regular expression
- eliminate the GNU awk `regexp escape sequence` warning while parsing rootfs manifests

## Validation
- parsed the published `v1.latest` amd64 manifest metadata successfully without warnings
- `bash -n runTcpQuality-rootfs.sh`
- v1beta amd64/arm64 rootfs CI passed

Test run: https://github.com/ibsgss/TcpQuality/actions/runs/30817377531