### PR TITLE
Make rootfs manifest parsing portable

### DIFF
--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -526,7 +526,7 @@ parse_rootfs_manifest() {
       line=$0; sub(/^.*"size"[[:space:]]*:[[:space:]]*/, "", line); sub(/[^0-9].*$/, "", line); size=line
     }
     inside && /^([[:space:]]*)}/ {
-      if (file != "" && sha ~ /^[0-9a-fA-F]{64}$/ && size ~ /^[0-9]+$/) print file "|" tolower(sha) "|" size
+      if (file != "" && length(sha) == 64 && sha !~ /[^0-9a-fA-F]/ && size ~ /^[0-9]+$/) print file "|" tolower(sha) "|" size
       exit
     }
   ' "$manifest"


### PR DESCRIPTION
## Summary
- replace the awk interval quantifier with a portable length and character validation
- prevent both ibsgss and GitHub rootfs sources from being rejected on awk implementations without reliable interval support

## Validation
- parsed the published `v1.latest` manifest successfully
- `bash -n runTcpQuality-rootfs.sh`
- v1beta amd64/arm64 rootfs CI passed

Test run: https://github.com/ibsgss/TcpQuality/actions/runs/30818795041