### PR TITLE
Bundle NextTrace in rootfs artifacts

### DIFF
--- a/.github/actions/build-rootfs/action.yml
+++ b/.github/actions/build-rootfs/action.yml
@@ -17,6 +17,7 @@ runs:
       env:
         TARGET_ARCH: ${{ inputs.arch }}
         RELEASE_MARKER: ${{ inputs.release-marker }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -Eeuo pipefail
         rm -rf build-context rootfs dist
@@ -38,6 +39,24 @@ runs:
           --build-arg "TCPQUALITY_ROOTFS_RELEASE=${RELEASE_MARKER}" \
           --output type=local,dest=rootfs \
           build-context
+        nexttrace_asset="nexttrace-tiny_linux_${TARGET_ARCH}"
+        nexttrace_api="https://api.github.com/repos/nxtrace/NTrace-core/releases/latest"
+        nexttrace_json=$(curl -fsSL --retry 3 \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "$nexttrace_api")
+        nexttrace_tag=$(jq -er '.tag_name' <<<"$nexttrace_json")
+        nexttrace_url=$(jq -er --arg name "$nexttrace_asset" \
+          '.assets[] | select(.name == $name) | .browser_download_url' <<<"$nexttrace_json")
+        nexttrace_digest=$(jq -er --arg name "$nexttrace_asset" \
+          '.assets[] | select(.name == $name) | .digest' <<<"$nexttrace_json")
+        [[ "$nexttrace_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
+        curl -fL --retry 3 --retry-all-errors \
+          --connect-timeout 15 --max-time 600 \
+          "$nexttrace_url" -o "$nexttrace_asset"
+        printf '%s  %s\n' "${nexttrace_digest#sha256:}" "$nexttrace_asset" | sha256sum -c -
+        install -m 0755 "$nexttrace_asset" rootfs/usr/local/bin/nexttrace-tiny
+        printf '%s\n' "$nexttrace_tag" > rootfs/etc/tcpquality-nexttrace-release
         tar --numeric-owner --xattrs --acls \
           -C rootfs -czf "dist/tcpquality-rootfs-${TARGET_ARCH}.tar.gz" .
 
@@ -53,6 +72,8 @@ runs:
         tar -tzf "$archive" > /tmp/rootfs-files.txt
         grep -qx './etc/os-release' /tmp/rootfs-files.txt
         grep -qx './etc/tcpquality-rootfs-release' /tmp/rootfs-files.txt
+        grep -qx './etc/tcpquality-nexttrace-release' /tmp/rootfs-files.txt
+        grep -qx './usr/local/bin/nexttrace-tiny' /tmp/rootfs-files.txt
         test "$(cat rootfs/etc/tcpquality-rootfs-release)" = "$RELEASE_MARKER"
         sudo chroot rootfs /bin/bash -lc '
           set -Eeuo pipefail
@@ -60,6 +81,7 @@ runs:
             command -v "$command_name" >/dev/null
           done
           nping --version >/dev/null
+          nexttrace-tiny -V >/dev/null
         '
         (
           cd dist

--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -24,6 +24,7 @@ ROOTFS_IBSGSS_BASE="${TCPQUALITY_ROOTFS_IBSGSS_BASE:-https://tcpquality.ibsgss.u
 OUTPUT_DIR="${TCPQUALITY_OUTPUT_DIR:-/tmp}"
 GUEST_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 NEXTTRACE_RELEASE_API=https://api.github.com/repos/nxtrace/NTrace-core/releases/latest
+NEXTTRACE_DOWNLOAD_TIMEOUT="${TCPQUALITY_NEXTTRACE_DOWNLOAD_TIMEOUT:-600}"
 DEBUG_MODE=0
 MIN_ROOTFS_FREE_KB=$((700 * 1024))
 
@@ -459,7 +460,9 @@ download_nexttrace_guest() {
   fi
 
   binary="$RUNTIME_DIR/$asset_name"
-  curl -fL --retry 3 --connect-timeout 15 --max-time 300 "$url" -o "$binary" ||
+  curl -fL --retry 3 --retry-all-errors --continue-at - \
+    --connect-timeout 15 --max-time "$NEXTTRACE_DOWNLOAD_TIMEOUT" \
+    "$url" -o "$binary" ||
     return 1
   if [ -n "$digest" ]; then
     verify_sha256 "$digest" "$binary" || return 1
@@ -904,10 +907,24 @@ install_guest_deps() {
 }
 
 prepare_guest_files() {
-  local nexttrace_path
+  local nexttrace_path arg
   mkdir -p "$ROOTFS_DIR/root" "$ROOTFS_DIR/usr/local/bin"
   cp "$TARGET_SCRIPT" "$ROOTFS_DIR/root/runTcpQuality.sh"
   chmod 0755 "$ROOTFS_DIR/root/runTcpQuality.sh"
+
+  for arg in "$@"; do
+    if [ "$arg" = "--only-speedtest" ]; then
+      echo "[i] 单线程测速无需 nexttrace-tiny，已跳过下载"
+      return 0
+    fi
+  done
+
+  if [ -x "$ROOTFS_DIR/usr/local/bin/nexttrace-tiny" ] &&
+     env -i HOME=/root "PATH=$GUEST_PATH" TERM=dumb \
+       chroot "$ROOTFS_DIR" /usr/local/bin/nexttrace-tiny -V >/dev/null 2>&1; then
+    echo "[√] 预构建 rootfs 已包含 nexttrace-tiny"
+    return 0
+  fi
 
   if download_nexttrace_guest; then
     return 0
@@ -935,7 +952,7 @@ case "$OUTPUT_DIR/" in
 esac
 mount_guest
 install_guest_deps || exit 1
-prepare_guest_files
+prepare_guest_files "$@"
 echo "[i] 进入临时 ${DISTRO} rootfs；退出后自动清理"
 if [ "$KEEP_ROOTFS" -eq 1 ]; then
   echo "[i] --keep 已启用，rootfs 保留于: $ROOTFS_DIR"


### PR DESCRIPTION
## Summary
- bundle verified NextTrace Tiny binaries into amd64 and arm64 rootfs artifacts
- validate NextTrace inside each built rootfs before packaging
- prefer the bundled binary at runtime and retain network download only as a fallback
- skip NextTrace preparation for `--only-speedtest`

## Validation
- v1beta CI passed shell validation and both architecture builds
- downloaded both artifacts and verified archive SHA-256 files
- confirmed both archives contain `/usr/local/bin/nexttrace-tiny` and version marker `v1.7.1`

CI: https://github.com/ibsgss/TcpQuality/actions/runs/30821104736