### PR TITLE
使用 xz 作为 rootfs 格式，以减小体积

### DIFF
--- a/.github/actions/build-rootfs/action.yml
+++ b/.github/actions/build-rootfs/action.yml
@@ -77,7 +77,7 @@ runs:
         install -m 0755 "$nexttrace_asset" rootfs/usr/local/bin/nexttrace-tiny
         printf '%s\n' "$nexttrace_tag" > rootfs/etc/tcpquality-nexttrace-release
         tar --numeric-owner --xattrs --acls \
-          -C rootfs -czf "dist/tcpquality-rootfs-${TARGET_ARCH}.tar.gz" .
+          -C rootfs -cJf "dist/tcpquality-rootfs-${TARGET_ARCH}.tar.xz" .
 
     - name: Validate rootfs
       shell: bash
@@ -86,9 +86,9 @@ runs:
         RELEASE_MARKER: ${{ inputs.release-marker }}
       run: |
         set -Eeuo pipefail
-        archive="dist/tcpquality-rootfs-${TARGET_ARCH}.tar.gz"
+        archive="dist/tcpquality-rootfs-${TARGET_ARCH}.tar.xz"
         test -s "$archive"
-        tar -tzf "$archive" > /tmp/rootfs-files.txt
+        tar -tJf "$archive" > /tmp/rootfs-files.txt
         grep -qx './etc/os-release' /tmp/rootfs-files.txt
         grep -qx './etc/tcpquality-rootfs-release' /tmp/rootfs-files.txt
         grep -qx './etc/tcpquality-nexttrace-release' /tmp/rootfs-files.txt
@@ -108,6 +108,6 @@ runs:
         '
         (
           cd dist
-          sha256sum "tcpquality-rootfs-${TARGET_ARCH}.tar.gz" \
-            | tee "tcpquality-rootfs-${TARGET_ARCH}.tar.gz.sha256"
+          sha256sum "tcpquality-rootfs-${TARGET_ARCH}.tar.xz" \
+            | tee "tcpquality-rootfs-${TARGET_ARCH}.tar.xz.sha256"
         )

--- a/.github/workflows/rootfs-ci.yml
+++ b/.github/workflows/rootfs-ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: rootfs-${{ matrix.arch }}
           path: |
-            dist/tcpquality-rootfs-${{ matrix.arch }}.tar.gz
-            dist/tcpquality-rootfs-${{ matrix.arch }}.tar.gz.sha256
+            dist/tcpquality-rootfs-${{ matrix.arch }}.tar.xz
+            dist/tcpquality-rootfs-${{ matrix.arch }}.tar.xz.sha256
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/rootfs-release.yml
+++ b/.github/workflows/rootfs-release.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rootfs-${{ matrix.arch }}
-          path: dist/tcpquality-rootfs-${{ matrix.arch }}.tar.gz
+          path: dist/tcpquality-rootfs-${{ matrix.arch }}.tar.xz
           if-no-files-found: error
           retention-days: 7
 
@@ -139,12 +139,12 @@ jobs:
             exit 1
           fi
           for arch in amd64 arm64; do
-            file="dist/tcpquality-rootfs-${arch}.tar.gz"
+            file="dist/tcpquality-rootfs-${arch}.tar.xz"
             test -s "$file"
             sha256sum "$file"
           done
-          amd64_file=tcpquality-rootfs-amd64.tar.gz
-          arm64_file=tcpquality-rootfs-arm64.tar.gz
+          amd64_file=tcpquality-rootfs-amd64.tar.xz
+          arm64_file=tcpquality-rootfs-arm64.tar.xz
           amd64_sha=$(sha256sum "dist/$amd64_file" | awk '{print $1}')
           arm64_sha=$(sha256sum "dist/$arm64_file" | awk '{print $1}')
           amd64_size=$(stat -c '%s' "dist/$amd64_file")
@@ -178,8 +178,8 @@ jobs:
           fi
           gh release create "$RELEASE_TAG" \
             dist/rootfs-manifest.json \
-            dist/tcpquality-rootfs-amd64.tar.gz \
-            dist/tcpquality-rootfs-arm64.tar.gz \
+            dist/tcpquality-rootfs-amd64.tar.xz \
+            dist/tcpquality-rootfs-arm64.tar.xz \
             --target "$GITHUB_SHA" \
             --title "$RELEASE_TAG" \
             --notes "Prebuilt Debian bookworm-slim rootfs for TcpQuality. Downloads are verified using the attached manifest."
@@ -194,16 +194,16 @@ jobs:
           git push --force origin "refs/tags/$ALIAS_TAG"
           if gh release view "$ALIAS_TAG" >/dev/null 2>&1; then
             gh release upload "$ALIAS_TAG" --clobber \
-              dist/tcpquality-rootfs-amd64.tar.gz \
-              dist/tcpquality-rootfs-arm64.tar.gz
+              dist/tcpquality-rootfs-amd64.tar.xz \
+              dist/tcpquality-rootfs-arm64.tar.xz
             gh release upload "$ALIAS_TAG" --clobber dist/rootfs-manifest.json
             gh release edit "$ALIAS_TAG" \
               --title "$ALIAS_TAG" \
               --notes "Stable alias for $RELEASE_TAG from $GITHUB_REF_NAME. Verify downloads with the attached manifest."
           else
             gh release create "$ALIAS_TAG" \
-              dist/tcpquality-rootfs-amd64.tar.gz \
-              dist/tcpquality-rootfs-arm64.tar.gz \
+              dist/tcpquality-rootfs-amd64.tar.xz \
+              dist/tcpquality-rootfs-arm64.tar.xz \
               dist/rootfs-manifest.json \
               --title "$ALIAS_TAG" \
               --notes "Stable alias for $RELEASE_TAG from $GITHUB_REF_NAME. Verify downloads with the attached manifest."

--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -566,7 +566,7 @@ download_prebuilt_debian_from() {
   local source="$1" base asset_base manifest manifest_url manifest_version archive metadata file checksum expected_size actual_size cache_buster
   base=$(rootfs_source_base "$source") || return 1
   manifest="$TEMP_ROOT_PARENT/rootfs-manifest-${source}.json"
-  archive="$TEMP_ROOT_PARENT/debian-rootfs-${source}.tar.gz"
+  archive="$TEMP_ROOT_PARENT/debian-rootfs-${source}.tar.xz"
   echo "[i] 尝试 ${source} 预构建 rootfs: ${ROOTFS_RELEASE_TAG}"
   cache_buster="$(date +%s)-$$"
   manifest_url="$base/rootfs-manifest.json?refresh=$cache_buster"
@@ -579,7 +579,7 @@ download_prebuilt_debian_from() {
   [ -n "$metadata" ] || return 1
   IFS='|' read -r file checksum expected_size <<< "$metadata"
   case "$file" in
-    tcpquality-rootfs-*.tar.gz) ;;
+    tcpquality-rootfs-*.tar.xz) ;;
     *) return 1 ;;
   esac
   echo "[i] 下载 rootfs: $asset_base/$file"

--- a/runTcpQuality-rootfs.sh
+++ b/runTcpQuality-rootfs.sh
@@ -563,10 +563,9 @@ parse_rootfs_manifest() {
 }
 
 download_prebuilt_debian_from() {
-  local source="$1" base asset_base manifest manifest_url manifest_version archive metadata file checksum expected_size actual_size cache_buster
+  local source="$1" base asset_base manifest manifest_url manifest_version archive tar_options metadata file checksum expected_size actual_size cache_buster
   base=$(rootfs_source_base "$source") || return 1
   manifest="$TEMP_ROOT_PARENT/rootfs-manifest-${source}.json"
-  archive="$TEMP_ROOT_PARENT/debian-rootfs-${source}.tar.xz"
   echo "[i] 尝试 ${source} 预构建 rootfs: ${ROOTFS_RELEASE_TAG}"
   cache_buster="$(date +%s)-$$"
   manifest_url="$base/rootfs-manifest.json?refresh=$cache_buster"
@@ -579,7 +578,14 @@ download_prebuilt_debian_from() {
   [ -n "$metadata" ] || return 1
   IFS='|' read -r file checksum expected_size <<< "$metadata"
   case "$file" in
-    tcpquality-rootfs-*.tar.xz) ;;
+    tcpquality-rootfs-*.tar.gz)
+      archive="$TEMP_ROOT_PARENT/debian-rootfs-${source}.tar.gz"
+      tar_options=-xzf
+      ;;
+    tcpquality-rootfs-*.tar.xz)
+      archive="$TEMP_ROOT_PARENT/debian-rootfs-${source}.tar.xz"
+      tar_options=-xJf
+      ;;
     *) return 1 ;;
   esac
   echo "[i] 下载 rootfs: $asset_base/$file"
@@ -598,7 +604,7 @@ download_prebuilt_debian_from() {
   fi
   rm -rf -- "$ROOTFS_DIR"
   mkdir -p "$ROOTFS_DIR"
-  if ! tar -xzf "$archive" -C "$ROOTFS_DIR"; then
+  if ! tar "$tar_options" "$archive" -C "$ROOTFS_DIR"; then
     rm -rf -- "$ROOTFS_DIR"
     mkdir -p "$ROOTFS_DIR"
     return 1


### PR DESCRIPTION
在引入 bpftrace / libbpfcc / libclang / libllvm 之后镜像体积膨胀了不少
使用更高效的压缩归档算法，减小镜像体积


rootfs-amd64 133MB -> **89.3MB**
rootfs-arm64 128MB -> **81.1MB**